### PR TITLE
Add type definitions from @types/yoga-layout

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,4 @@
+declare module 'yoga-layout-prebuilt' {
+	import type * as Yoga from 'yoga-layout'
+	export = Yoga;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,18 @@
-declare module 'yoga-layout-prebuilt' {
-	import type * as Yoga from 'yoga-layout'
-	export = Yoga;
+declare module "yoga-layout-prebuilt" {
+	export {
+		default,
+		YogaNode,
+		YogaConfig,
+		YogaAlign,
+		YogaDirection,
+		YogaDisplay,
+		YogaEdge,
+		YogaFlexDirection,
+		YogaExperimentalFeature,
+		YogaFlexWrap,
+		YogaJustifyContent,
+		YogaOverflow,
+		YogaPositionType,
+		YogaUnit
+	} from "yoga-layout";
 }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
 		"prepublishOnly": "./build.sh"
 	},
 	"main": "yoga-layout/dist/entry-browser",
+	"types": "index.d.ts",
 	"files": [
-		"yoga-layout"
+		"yoga-layout",
+		"index.d.ts"
 	],
 	"keywords": [
 		"yoga",
@@ -32,5 +34,8 @@
 		"ignores": [
 			"yoga-layout"
 		]
+	},
+	"dependencies": {
+		"@types/yoga-layout": "1.9.1"
 	}
 }


### PR DESCRIPTION
## Motivation

I'm preparing a PR that to Ink that will convert the entire project to TypeScript. I would like to be able to use this package in Ink project without doing anything special in Ink. This also closes #6 

## Approach

I'm assuming that `yoga-layout-prebuilt` has the same exports as `yoga-layout` so I'm importing `@types/yoga-layout` and exporting them under `yoga-layout-prebuilt` module.

## TODO

- [ ] Add tests for the definitions