### PR TITLE
Fixed uninitialized variable error in strict mode

### DIFF
--- a/yoga-layout/build/Release/nbind.js
+++ b/yoga-layout/build/Release/nbind.js
@@ -1143,7 +1143,7 @@
       }
     }_nbind.addMethod = addMethod;function throwError(message) {
       throw new Error(message);
-    }_nbind.throwError = throwError;_nbind.bigEndian = false;_a = _typeModule(_typeModule), _nbind.Type = _a.Type, _nbind.makeType = _a.makeType, _nbind.getComplexType = _a.getComplexType, _nbind.structureList = _a.structureList;var BindType = function (_super) {
+    }var _a;_nbind.throwError = throwError;_nbind.bigEndian = false;_a = _typeModule(_typeModule), _nbind.Type = _a.Type, _nbind.makeType = _a.makeType, _nbind.getComplexType = _a.getComplexType, _nbind.structureList = _a.structureList;var BindType = function (_super) {
       __extends(BindType, _super);function BindType() {
         var _this = _super !== null && _super.apply(this, arguments) || this;_this.heap = HEAPU32;_this.ptrSize = 4;return _this;
       }BindType.prototype.needsWireRead = function (policyTbl) {


### PR DESCRIPTION
Using yoga-layout-prebuilt with type="module" triggers an error

```
Uncaught ReferenceError: _a is not defined ... at node_modules/yoga-layout-prebuilt/yoga-layout/dist/entry-browser.js (:3000/node_modules/.vite/@react-three_flex.js?v=63c167e0:27914)
```

Adding variable declaration fixes it

It all started in https://github.com/pmndrs/react-three-flex/issues/66